### PR TITLE
Evolve printing algorithm and improve testing

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -230,8 +230,20 @@
       (display-val proc v)
       (proc 'flush))))
 
-(define (w/rule str)
-  (string-append "\n----|----1----|----2----|----3----|\n"
+;; 25 → "----|----1----|----2----|"
+(define (rule n)
+  (list->string
+   (for/list ([i (in-range n)])
+     (define col (+ 1 i))
+     (cond
+       [(eqv? 0 (modulo col 10))
+        (integer->char (+ 48 (/ col 10)))] ; 48 = #\0
+       [(eqv? 0 (modulo col 5))
+        #\|]
+       [else #\-]))))        
+
+(define (w/rule width str)
+  (string-append "\n" (rule (+ width 15)) "\n"
                  (string-replace str " " "·")))
 
 (define (debug v #:wrap [wrap 20])
@@ -246,7 +258,7 @@
 
   ;; Nice for visual checks
   (define (disp v)
-    (displayln "----|----1----|----2----|----3----|")
+    (displayln (rule 35))
     (display (xexpr->html5 v #:wrap 20)))
 
   (define-check (check-fmt width msg xpr strs)
@@ -254,8 +266,8 @@
     (define standard (string-join strs (sys-newline)))
     (unless (equal? my-result standard)
       (with-check-info (['message (string-info msg)]
-                        ['|writer result| (string-info (w/rule my-result))]
-                        ['expected (string-info (w/rule standard))])
+                        ['|writer result| (string-info (w/rule width my-result))]
+                        ['expected (string-info (w/rule width standard))])
         (fail-check))))
 
   (define-check (check-matches-tidy? width x)
@@ -263,8 +275,8 @@
     (define tidy-result (string-append (tidy x #:wrap width) "\n"))
     (unless (equal? my-result tidy-result)
       (with-check-info (['message (string-info "writer result does not match expected tidy output")]
-                        ['|writer result| (string-info (w/rule my-result))]
-                        ['|tidy output| (string-info (w/rule tidy-result))])
+                        ['|writer result| (string-info (w/rule width my-result))]
+                        ['|tidy output| (string-info (w/rule width tidy-result))])
         (fail-check))))
 
   (check-fmt 20 "Naked strings work correctly" " Hi" '("Hi"))

--- a/main.rkt
+++ b/main.rkt
@@ -243,8 +243,10 @@
        [else #\-]))))        
 
 (define (w/rule width str)
-  (string-append "\n" (rule (+ width 15)) "\n"
-                 (string-replace str " " "·")))
+  (string-append (sys-newline) (rule (+ width 15)) (sys-newline)
+                 (string-replace
+                  (string-replace str " " "·")
+                  (sys-newline) (string-append "¶" (sys-newline)))))
 
 (define (debug v #:wrap [wrap 20])
   (display (w/rule wrap (logging-to-stderr (lambda () (xexpr->html5 v #:wrap wrap))))))

--- a/main.rkt
+++ b/main.rkt
@@ -108,7 +108,8 @@
 
 (define (display-val yeet! v [prev-token 'normal] #:in-inline? [inside-inline? #f])
   (match v
-    [(list (and (? symbol?) (? br?)))
+    [(? null?) prev-token]
+    [(list* (and (? symbol?) (? br?)) _)
      (log-debug "[prev ~a] br" prev-token)
      (yeet! '(put/wrap "<br>") 'flush 'break/indent)
      'flow-opened] ; hacky
@@ -359,7 +360,7 @@
              '("<p>one<br>"
                "two three four five"
                "six</p>\n"))
-
+  
   #;(check-matches-tidy? 20 '(p "one" (br) "two three four five six"))
 
   (check-fmt 20 "linebreaks not inserted where they would introduce whitespace (following inline tag close)"
@@ -471,6 +472,21 @@
              '("<div>"
                "  <pre>&mdash;&#20;</pre>"
                "</div>\n"))
+
+  (check-fmt 20 "Handle empty attribute lists, esp. in <br> tags (Koyo/HAML)"
+             '(body ()
+                    (header ()
+                            (h1 () "Title")
+                            (p () "a"
+                               (br ())
+                               "b")))
+             '("<body>"
+               "  <header>"
+               "    <h1>Title</h1>"
+               "    <p>a<br>"
+               "    b</p>"
+               "  </header>"
+               "</body>\n"))
   
   (check-fmt 20 "<head> wraps/indents correctly"
              '(html (head (link [[rel "stylesheet"] [href "style.css"]])

--- a/main.rkt
+++ b/main.rkt
@@ -281,6 +281,11 @@
                           ['|writer result| (string-info (w/rule width my-result))]
                           ['|tidy output| (string-info (w/rule width tidy-result))])
           (fail-check)))))
+  
+  (if (tidy-version-sufficient?)
+    (eprintf "Test harness using HTML Tidy version ~a for comparison checks\n" (get-tidy-version))
+    (eprintf "No stable release of HTML Tidy >= ~a found, skipping Tidy comparison checks\n"
+             minimum-tidy-version))
 
   (check-fmt 20 "Naked strings work correctly" " Hi" '("Hi"))
   

--- a/main.rkt
+++ b/main.rkt
@@ -247,7 +247,7 @@
                  (string-replace str " " "·")))
 
 (define (debug v #:wrap [wrap 20])
-  (display (w/rule (logging-to-stderr (lambda () (xexpr->html5 v #:wrap wrap))))))
+  (display (w/rule wrap (logging-to-stderr (lambda () (xexpr->html5 v #:wrap wrap))))))
 
 (module+ test
   (require "private/tidy.rkt"

--- a/main.rkt
+++ b/main.rkt
@@ -270,14 +270,17 @@
                         ['expected (string-info (w/rule width standard))])
         (fail-check))))
 
+  ;; Check the writer's result against the output of HTML Tidy.
+  ;; If a sufficiently new version of HTML Tidy is not installed, check passes.
   (define-check (check-matches-tidy? width x)
-    (define my-result (xexpr->html5 (xpr x) #:wrap width))
-    (define tidy-result (string-append (tidy x #:wrap width) "\n"))
-    (unless (equal? my-result tidy-result)
-      (with-check-info (['message (string-info "writer result does not match expected tidy output")]
-                        ['|writer result| (string-info (w/rule width my-result))]
-                        ['|tidy output| (string-info (w/rule width tidy-result))])
-        (fail-check))))
+    (when (tidy-version-sufficient?)
+      (define my-result (xexpr->html5 (xpr x) #:wrap width))
+      (define tidy-result (string-append (tidy x #:wrap width) "\n"))
+      (unless (equal? my-result tidy-result)
+        (with-check-info (['message (string-info "writer result does not match expected tidy output")]
+                          ['|writer result| (string-info (w/rule width my-result))]
+                          ['|tidy output| (string-info (w/rule width tidy-result))])
+          (fail-check)))))
 
   (check-fmt 20 "Naked strings work correctly" " Hi" '("Hi"))
   
@@ -333,11 +336,11 @@
   ; Block and inline elements as siblings
 
   (check-fmt 20 "Escape < > & in string elements, and < > & \" in attributes"
-               '(span [[x "<\">&"]] "Symbols < \" > &")
-               '("<span x="
-                 "\"&lt;&quot;&gt;&amp;\">"
-                 "Symbols &lt; \" &gt;"
-                 "&amp;</span>"))
+             '(span [[x "<\">&"]] "Symbols < \" > &")
+             '("<span x="
+               "\"&lt;&quot;&gt;&amp;\">"
+               "Symbols &lt; \" &gt;"
+               "&amp;</span>"))
   
   #;(check-matches-tidy? 20 '(span [[x "<\">&"]] "Symbols < \" > &"))
 
@@ -407,10 +410,10 @@
   ;; Not passing yet! requires looking ahead before printing opening <i>
   
   (check-fmt 20 "allow wrap between inline elements when first ends in whitespace"
-               '(p (span "one two three ") (i "four"))
-               '("<p><span>one two"
-                 "three </span><i>"
-                 "four</i></p>\n"))
+             '(p (span "one two three ") (i "four"))
+             '("<p><span>one two"
+               "three </span><i>"
+               "four</i></p>\n"))
 
   #;(check-matches-tidy? 20 '(p (span "one two three ") (i "four")))
   

--- a/main.rkt
+++ b/main.rkt
@@ -467,6 +467,12 @@
                "    three</pre>"
                "</div>\n"))
 
+  (check-fmt 20 "Pre tags handle contained xexprs"
+             '(div (pre "Hello " (i "World")))
+             '("<div>"
+               "  <pre>Hello <i>World</i></pre>"
+               "</div>\n"))
+
   (check-fmt 20 "Symbols and integers inside pre/script converted to entities"
              '(div (pre mdash 20))
              '("<div>"

--- a/main.rkt
+++ b/main.rkt
@@ -210,16 +210,10 @@
        [(or (not (whitespace? last-word)) (= 1 count)) 'sticky]
        [else 'normal])]
 
-    [(? symbol? s)
-     (log-debug "[prev ~a] symbol ~a" prev-token s)
-     (define out-str (format "&~a;" s))
-     (yeet! `(,(if (sticky? prev-token) 'put 'put/wrap) ,out-str))
-     'sticky]
-    
-    [(? exact-positive-integer? i)
-     (log-debug "[prev ~a] integer ~a" prev-token i)
-     (define out-str (format "&#~a;" i))
-     (yeet! `(,(if (sticky? prev-token) 'put 'put/wrap) ,out-str))
+    [(or (? symbol? v)
+         (? exact-positive-integer? v))
+     (log-debug "[prev ~a] ~a" prev-token v)
+     (yeet! `(,(if (sticky? prev-token) 'put 'put/wrap) ,v))
      'sticky]
     ))
 
@@ -470,6 +464,12 @@
                "one"
                "  two  "
                "    three</pre>"
+               "</div>\n"))
+
+  (check-fmt 20 "Symbols and integers inside pre/script converted to entities"
+             '(div (pre mdash 20))
+             '("<div>"
+               "  <pre>&mdash;&#20;</pre>"
                "</div>\n"))
   
   (check-fmt 20 "<head> wraps/indents correctly"

--- a/private/printer.rkt
+++ b/private/printer.rkt
@@ -3,6 +3,7 @@
 (require "strings.rkt"
          "log.rkt"
          (only-in racket/syntax format-symbol)
+         racket/mutable-treelist
          unicode-breaks)
 
 (provide make-wrapping-printer)
@@ -10,23 +11,114 @@
 (define (make-wrapping-printer [outp (current-output-port)]
                                #:wrap-at [wrap-col 100]
                                #:indent-spaces [indent 2])
-  (let ([col 1]                           
-        [indent-level 0]
-        [logical-line-start #t])
+  
+  (let ([col 1]                   ; column of next char, counting actually-printed chars
+        [indent-level 0]          ; indent level in columns
+        [logical-line-start #t]   ; at "start"? (ignoring whitespace) counting actually-printed chars
+        [accum-width 0]           ; length of strings in accumulator
+        [accumulator (mutable-treelist)]) ; accumulator (list of strings not yet actually printed)
+
+    (define (accum-empty?)
+      (mutable-treelist-empty? accumulator))
+
+    (define (accum-end-is-whsp? which-end)
+      (and (not (accum-empty?))
+           (whitespace? ((if (eq? which-end 'right)
+                             mutable-treelist-last
+                             mutable-treelist-first)
+                         accumulator))))
+
+    (define (lop-accum-whsp-end! which-end)
+      (cond
+        [(and (not (accum-empty?))
+              (accum-end-is-whsp? which-end))
+         (define-values (tl-get tl-drop)
+           (case which-end
+             [(left)  (values mutable-treelist-first mutable-treelist-drop!)]
+             [(right) (values mutable-treelist-last mutable-treelist-drop-right!)]))
+         (do () [(not (accum-end-is-whsp? which-end))]
+           (let ([last-len (string-grapheme-count (tl-get accumulator))])
+             (log-debug "accum width ~a - ~a (~a)" accum-width last-len which-end)
+             (set! accum-width (- accum-width last-len))
+             (tl-drop accumulator 1)))
+         #t]
+        [else #f]))
+
+    (define (flush!)
+      (unless (accum-empty?)
+        (log-debug "flushing accumulator: ~v" accumulator)
+        (define lopped? (lop-accum-whsp-end! 'right))
+        (for ([v (in-mutable-treelist accumulator)])
+          (display v outp)
+          (when (and logical-line-start (not (whitespace? v)))
+            (set! logical-line-start #f)))
+        (set! col (+ col accum-width))
+        (set! accum-width 0)
+        (mutable-treelist-take! accumulator 0)
+        (when (and lopped? (not logical-line-start))
+          (accumulate! " "))))
+    
+    (define (flush-accumulator!)
+      (unless (accum-empty?)
+        (when (and (not logical-line-start) (> (+ col accum-width) wrap-col)) (break+indent!))
+        (flush!)))
+        
+    (define (break!)
+      (log-debug "break!")
+      (flush!)
+      (display (sys-newline) outp)
+      (set! logical-line-start #t)
+      (set! col 1))
+    
     (define (break+indent!)
+      (log-debug "break+indent!")
       (display (sys-newline) outp)
       (display (make-string indent-level #\space) outp)
       (set! logical-line-start #t)
-      (set! col (+ 1 indent-level)))
+      (set! col (+ 1 indent-level))
+      (lop-accum-whsp-end! 'left))
+
+    (define (accumulate! str)
+      (define whsp? (whitespace? str))
+      (define len (string-grapheme-count str))
+      (unless (or (equal? "" str)
+                  (and logical-line-start (accum-empty?) whsp?))
+        (mutable-treelist-add! accumulator str)
+        (set! accum-width (+ accum-width len))
+        (log-debug "Accumulator now (~a + ~a): ~v" col accum-width accumulator)))
+
+    (define (accumulate/wrap! str)
+      (cond
+        [(> (+ col accum-width (string-grapheme-count str)) wrap-col)
+         (flush-accumulator!)
+         (accumulate! str)]
+        [else (accumulate! str)]))
+
+    (define (put! str)
+      (unless (whitespace? str) (set! logical-line-start #f))
+      (set! col
+            (for/fold ([c col])
+                      ([w (in-words str)])
+              (display w outp)
+              (cond [(linebreak? w)
+                     (set! logical-line-start #t)
+                     1]
+                    [else (+ c (string-grapheme-count w))]))))
+    
     (define proc
       (lambda args
         (unless (null? args)
           (define arg (car args))
           (case arg
+            [(get-line-length) wrap-col]
             [(break)
-             (display (sys-newline) outp)
-             (set! logical-line-start #t)
-             (set! col 1)]
+             (break!)]
+            [(check/flush)
+             (log-debug "check/flush, (+ ~a ~a) > ~a = ~a" col accum-width wrap-col
+                        (> (+ col accum-width) wrap-col))
+             (when (> (+ col accum-width) wrap-col) (flush-accumulator!))]
+            [(flush)
+             (flush-accumulator!)]
             [(indent)
              (display (make-string indent-level #\space) outp)
              (set! col (+ col indent-level))]
@@ -35,38 +127,29 @@
                (display (make-string indent-level #\space) outp)
                (set! col (+ col indent-level)))]
             [(--indent)
+             (log-debug "(--indent)")
              (set! indent-level (max 0 (- indent-level indent)))
              (display (make-string indent-level #\space) outp)
              (set! col (+ col indent-level))]
             [(break/indent)
              (break+indent!)]
             [(break/++indent)
+             (log-debug "(break/++indent)")
              (set! indent-level (+ indent-level indent))
              (break+indent!)]
             [(break/--indent)
+             (log-debug "(break/--indent)")
              (set! indent-level (max 0 (- indent-level indent)))
              (break+indent!)]
             [else
              (when (and (list? arg) (not (null? arg)) (not (null? (cdr arg))))
                (define-values (sym str) (values (car arg) (cadr arg)))
-               (case (car arg)
+               (case sym
                  [(put)
-                  (unless (whitespace? str) (set! logical-line-start #f))
-                  (set! col
-                        (for/fold ([c col])
-                                  ([w (in-words str)])
-                          (display w outp)
-                          (cond [(linebreak? w)
-                                 (set! logical-line-start #t)
-                                 1]
-                                [else (+ c (string-grapheme-count w))])))]
+                  (cond
+                    [(accum-empty?) (put! str)]
+                    [else (accumulate! str)])]
                  [(put/wrap)
-                  (define len (string-grapheme-count str))
-                  (define whsp? (whitespace? str))
-                  (cond [(> (+ col len) wrap-col) (break+indent!)])
-                  (unless (and logical-line-start whsp?)
-                    (display str outp)
-                    (set! col (+ col len)))
-                  (unless whsp? (set! logical-line-start #f))]))])
+                  (accumulate/wrap! str)]))])
           (unless (null? (cdr args)) (apply proc (cdr args))))))
     (procedure-rename proc (format-symbol "wrapping-printer[cols:~a,sp:~a]" wrap-col indent))))

--- a/private/printer.rkt
+++ b/private/printer.rkt
@@ -78,7 +78,8 @@
       (set! col (+ 1 indent-level))
       (lop-accum-whsp-end! 'left))
 
-    (define (accumulate! str)
+    (define (accumulate! v)
+      (define str (->string v))
       (define whsp? (whitespace? str))
       (define len (string-grapheme-count str))
       (unless (or (equal? "" str)
@@ -87,14 +88,15 @@
         (set! accum-width (+ accum-width len))
         (log-debug "Accumulator now (~a + ~a): ~v" col accum-width accumulator)))
 
-    (define (accumulate/wrap! str)
+    (define (accumulate/wrap! v)
       (cond
-        [(> (+ col accum-width (string-grapheme-count str)) wrap-col)
+        [(> (+ col accum-width (string-grapheme-count v)) wrap-col)
          (flush-accumulator!)
-         (accumulate! str)]
-        [else (accumulate! str)]))
+         (accumulate! v)]
+        [else (accumulate! v)]))
 
-    (define (put! str)
+    (define (put! v)
+      (define str (->string v))
       (unless (whitespace? str) (set! logical-line-start #f))
       (set! col
             (for/fold ([c col])

--- a/private/semver.rkt
+++ b/private/semver.rkt
@@ -4,7 +4,9 @@
          racket/match
          racket/string)
 
-(provide try-extract-version version>=?)
+(provide try-extract-version
+         version>=?
+         minor-version)
 
 (define (try-extract-version str)
   (and (string? str)
@@ -18,6 +20,9 @@
                                    (parse-semver-version ver2))
       [(or 0 1) #true]
       [_ #false])))
+
+(define (minor-version ver-str)
+  (SemverVersion-minor (parse-semver-version ver-str)))
 
 ;; Stripped-down non-typed version of Alexis King's semver package.
 ;; Dropped in here to avoid extra dependencies on semver and alexis-util.

--- a/private/semver.rkt
+++ b/private/semver.rkt
@@ -1,0 +1,137 @@
+#lang racket/base
+
+(require racket/list
+         racket/match
+         racket/string)
+
+(provide try-extract-version version>=?)
+
+(define (try-extract-version str)
+  (and (string? str)
+       (match (regexp-match semver-regex-anywhere str)
+         [(? list? l) (car l)]
+         [_ #f])))
+
+(define (version>=? ver1 ver2)
+  (with-handlers ([exn:fail:contract? (λ (_) #false)])
+    (match (semver-version-compare (parse-semver-version ver1)
+                                   (parse-semver-version ver2))
+      [(or 0 1) #true]
+      [_ #false])))
+
+;; Stripped-down non-typed version of Alexis King's semver package.
+;; Dropped in here to avoid extra dependencies on semver and alexis-util.
+;; https://github.com/lexi-lambda/racket-semver/blob/fee107ee2401b5f7d7d797258eab3062ddb71232/semver/main.rkt
+
+#|
+Copyright 2015 Alexis King
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+|#
+
+(define _semver-regex
+  (string-append
+   "(\\d+)\\.(\\d+)\\.(\\d+)"  ; digits
+   "(?:-([0-9A-Za-z\\-]+"       ; suffix start
+   "(?:\\.[0-9A-Za-z\\-]+)*))?" ; rest of suffix
+   "(?:\\+[0-9A-Za-z\\-]+"      ; build metadata start
+   "(?:\\.[0-9A-Za-z\\-]+)*)?" ; rest of build metadata
+   ))
+
+(define semver-regex-anywhere
+  (pregexp _semver-regex))
+
+(define semver-regex
+  (pregexp (string-append "^" _semver-regex "$")))
+
+(struct SemverVersion (major minor patch suffix) #:transparent)
+
+; Utility function to parse strings to integers.
+(define (string->integer s)
+  (cond
+    [(not s) #f]
+    [else
+     (define i (string->number s))
+     (if (exact-integer? i) i #f)]))
+
+; Compares two integers
+(define (integer-compare i1 i2)
+  (cond
+    [(= i1 i2) 0]
+    [(> i1 i2) 1]
+    [else     -1]))
+
+; Compares two semver suffixes
+(define (semver-suffix-compare s1 s2)
+  (match (list s1 s2)
+    ['(() ()) 0]
+    [(list _ '()) 1]
+    [(list '() _) -1]
+    [(list (list (? string?) ___) (list (? exact-integer?) ___)) 1]
+    [(list (list (? exact-integer?) ___) (list (? string?) ___)) -1]
+    [(list (list-rest v1 rest1) (list-rest v2 rest2))
+     (cond
+       [(exact-integer? v1)
+        (cond
+          [(> v1 v2) 1]
+          [(< v1 v2) -1]
+          [else (semver-suffix-compare rest1 rest2)])]
+       [else
+        (cond
+          [(string>? v1 v2) 1]
+          [(string<? v1 v2) -1]
+          [else (semver-suffix-compare rest1 rest2)])])
+     ]))
+
+; Compares two semver versions
+(define (semver-version-compare v1 v2)
+  (let ([major1 (SemverVersion-major v1)]
+        [major2 (SemverVersion-major v2)]
+        [minor1 (SemverVersion-minor v1)]
+        [minor2 (SemverVersion-minor v2)]
+        [patch1 (SemverVersion-patch v1)]
+        [patch2 (SemverVersion-patch v2)]
+        [suffix1 (SemverVersion-suffix v1)]
+        [suffix2 (SemverVersion-suffix v2)])
+    (if (not (= major1 major2)) (integer-compare major1 major2)
+        (if (not (= minor1 minor2)) (integer-compare minor1 minor2)
+            (if (not (= patch1 patch2)) (integer-compare patch1 patch2)
+                (match (list suffix1 suffix2)
+                  [(list '() '()) 0]
+                  [(list '() _) 1]
+                  [(list _ '()) -1]
+                  [else (semver-suffix-compare suffix1 suffix2)]))))))
+
+; Checks if a given string is a valid semver version.
+(define (semver-version? str)
+  (regexp-match? semver-regex str))
+
+; Parses a possible semver suffix to a list of the dot-separated components.
+(define (parse-semver-suffix str)
+  (cond
+    [(not str) '()]
+    [else
+     (define split (string-split str "."))
+     (for/list ([x (in-list split)])
+       (or (string->integer x) x))]))
+
+; Parses a string to a semver.
+(define (parse-semver-version str)
+  (define data (regexp-match semver-regex str))
+  (cond
+    [data
+     (SemverVersion (string->integer (second data))
+                    (string->integer (third data))
+                    (string->integer (fourth data))
+                    (parse-semver-suffix (fifth data)))]
+    [else (raise-argument-error 'parse-semver-version "semver-version?" str)]))

--- a/private/strings.rkt
+++ b/private/strings.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
-(require racket/match)
+(require racket/match
+         xml)
 
 (provide whitespace?
          linebreak?
@@ -33,7 +34,9 @@
   (cond
     [(string? v) v]
     [(symbol? v) (format "&~a;" v)]
-    [(exact-positive-integer? v) (format "&#~a;" v)]))
+    [(exact-positive-integer? v) (format "&#~a;" v)]
+    [(null? v) ""]
+    [(xexpr? v) (xexpr->string v)]))
 
 (module+ test
   (require rackunit)

--- a/private/strings.rkt
+++ b/private/strings.rkt
@@ -10,17 +10,22 @@
          sys-newline
          escape
          string-element-table
-         attribute-table)
+         attribute-table
+         breakpoint
+         (rename-out [_bp? breakpoint?]))
+
+(struct _bp ())
+(define breakpoint (_bp))
 
 (define newline-convention (make-parameter (system-type)))
 
 (define (sys-newline)
   (if (eq? (newline-convention) 'windows) "\r\n" "\n"))
 
-;; Test if a string consists entirely of whitespace.
+;; Predicate returning true if val is a string consisting entirely of whitespace (or nothing).
 ;; NB: A non-breaking space is not counted as whitespace.
-(define (whitespace? s)
-  (match s
+(define (whitespace? v)
+  (match v
     ["" #t]
     [(pregexp #px"^[\\s]+$") #t]
     [_ #f]))

--- a/private/strings.rkt
+++ b/private/strings.rkt
@@ -4,6 +4,7 @@
 
 (provide whitespace?
          linebreak?
+         ->string
          newline-convention
          sys-newline
          escape
@@ -26,6 +27,13 @@
 ;; Test if a string consists only of \r or \n.
 (define (linebreak? s)
   (regexp-match? #rx"^[\r\n]+$" s))
+
+;; Coerce to string; as HTML entity when necessary
+(define (->string v)
+  (cond
+    [(string? v) v]
+    [(symbol? v) (format "&~a;" v)]
+    [(exact-positive-integer? v) (format "&#~a;" v)]))
 
 (module+ test
   (require rackunit)

--- a/private/tidy.rkt
+++ b/private/tidy.rkt
@@ -1,11 +1,95 @@
 #lang racket/base
 
-(require  (prefix-in base: xml)
+(require  "semver.rkt"
+          racket/match
           racket/port
           racket/string
-          racket/system)
+          racket/system
+          xml)
 
-(provide (all-defined-out))
+(provide tidy-path
+         tidy-options
+         get-tidy-version
+         tidy-version-sufficient?
+         tidy
+         xpr)
+
+(define minimum-tidy-version "5.8.0")
+(define tidy-path (make-parameter #f (λ (v) (_unset-tidy-version!) v)))
+(define tidy-options (make-parameter "-quiet -indent --wrap-attributes no --tidy-mark no"))
+
+(define (maybe-executable p)
+  (and p
+       (file-exists? p)
+       (member 'execute (file-or-directory-permissions p))
+       p))
+
+; If (tidy-path) is non-false and points to an existing executable
+(define _tidy-path/param-or-cached
+  (let ([tp #f])
+    (lambda ()
+      (cond
+        [(maybe-executable (tidy-path))]
+        [tp]
+        [else
+         (set! tp (or (maybe-executable (getenv "HTML_TIDY_PATH"))
+                      (find-executable-path "tidy")))
+         tp]))))
+
+(define-values (get-tidy-version
+                tidy-version-sufficient?
+                _unset-tidy-version!)
+  (let ([tidy-version #f]
+        [version-sufficient-flag #f])
+    (define (_getv)
+      (cond
+        [tidy-version]
+        [else
+         (define v-str (try-extract-version (try-tidy-version-cmd)))
+         (set! tidy-version (or v-str "0.0.0"))
+         tidy-version]))
+    (define (_vs?)
+      (case version-sufficient-flag
+        [(#f)
+         (define cmp (version>=? (_getv) minimum-tidy-version))
+         (set! version-sufficient-flag (if cmp 'yes 'no))
+         cmp]
+        [(yes) #t]
+        [(no) #f]))
+    (define (_unset!)
+      (set! tidy-version #f)
+      (set! version-sufficient-flag #f))
+    (values _getv _vs? _unset!)))
+
+(define (try-tidy-version-cmd)
+  (match (_tidy-path/param-or-cached)
+    [(? string? tp)
+     (with-output-to-string (lambda () (system (format "~a --version" tp))))]
+    [_ #f]))
+
+(define (tidy/raw [xp '(p "a")] [wrap-col 100])
+  (define tp (_tidy-path/param-or-cached))
+  (define opts (format "~a --wrap ~a" (tidy-options) wrap-col))
+  (parameterize ([current-input-port (open-input-string (htmlify xp))])
+    (with-output-to-string
+      (lambda ()
+        (system (format "~a ~a" tp opts))))))
+
+(define (tidy xp
+              #:extract-tag [tag (or (and (eq? 'head (car xp)) 'head) 'body)]
+              #:wrap [wrap-col 100])
+  (cond
+    [(tidy-version-sufficient?)
+     (define tp (_tidy-path/param-or-cached))
+     (define opts
+       (format "~a --wrap ~a" (tidy-options) wrap-col))
+     (define result
+       (parameterize ([current-input-port (open-input-string (htmlify xp))])
+         (with-output-to-string
+           (lambda ()
+             (system (format "~a ~a" tp opts))))))
+     (car (regexp-match (regexp (format "(<~a>.+</~a>)" tag tag)) result))]
+    [else #f]))
 
 (define (xpr x)
   (or (and (member (car x) '(head body)) x)
@@ -15,23 +99,10 @@
   (case (car x)
     [(head)
      (format "<!DOCTYPE html><html lang=\"en\">~a<body></body></html>"
-             (base:xexpr->string x))]
+             (xexpr->string x))]
     [(body)
      (format "<!DOCTYPE html><html lang=\"en\"><head><title>Test</title></head>~a</html>"
-             (base:xexpr->string x))]
+             (xexpr->string x))]
     [else
      (format "<!DOCTYPE html><html lang=\"en\"><head><title>Test</title></head>~a</html>"
-             (base:xexpr->string (xpr x)))]))
-
-(define tidy-path (make-parameter "/opt/homebrew/bin/tidy"))
-(define tidy-options (make-parameter "-quiet -indent --wrap-attributes no --tidy-mark no"))
-
-(define (tidy/raw xp [wrap-col 100])
-  (define opts (string-split (format "~a --wrap ~a" (tidy-options) wrap-col)))
-  (with-output-to-string
-    (lambda ()
-      (parameterize ([current-input-port (open-input-string (htmlify xp))])
-        (apply system* (tidy-path) opts)))))
-
-(define (tidy xpr #:extract-tag [tag (or (and (eq? 'head (car xpr)) 'head) 'body)] #:wrap [wrap-col 100])
-  (car (regexp-match (regexp (format "(<~a>.+</~a>)" tag tag)) (tidy/raw xpr wrap-col))))
+             (xexpr->string (xpr x)))]))

--- a/private/tidy.rkt
+++ b/private/tidy.rkt
@@ -1,0 +1,37 @@
+#lang racket/base
+
+(require  (prefix-in base: xml)
+          racket/port
+          racket/string
+          racket/system)
+
+(provide (all-defined-out))
+
+(define (xpr x)
+  (or (and (member (car x) '(head body)) x)
+      `(body (main (article ,x)))))
+
+(define (htmlify x)
+  (case (car x)
+    [(head)
+     (format "<!DOCTYPE html><html lang=\"en\">~a<body></body></html>"
+             (base:xexpr->string x))]
+    [(body)
+     (format "<!DOCTYPE html><html lang=\"en\"><head><title>Test</title></head>~a</html>"
+             (base:xexpr->string x))]
+    [else
+     (format "<!DOCTYPE html><html lang=\"en\"><head><title>Test</title></head>~a</html>"
+             (base:xexpr->string (xpr x)))]))
+
+(define tidy-path (make-parameter "/opt/homebrew/bin/tidy"))
+(define tidy-options (make-parameter "-quiet -indent --wrap-attributes no --tidy-mark no"))
+
+(define (tidy/raw xp [wrap-col 100])
+  (define opts (string-split (format "~a --wrap ~a" (tidy-options) wrap-col)))
+  (with-output-to-string
+    (lambda ()
+      (parameterize ([current-input-port (open-input-string (htmlify xp))])
+        (apply system* (tidy-path) opts)))))
+
+(define (tidy xpr #:extract-tag [tag (or (and (eq? 'head (car xpr)) 'head) 'body)] #:wrap [wrap-col 100])
+  (car (regexp-match (regexp (format "(<~a>.+</~a>)" tag tag)) (tidy/raw xpr wrap-col))))

--- a/private/tidy.rkt
+++ b/private/tidy.rkt
@@ -53,8 +53,8 @@
         [tp]
         [else
          (set! tp (or (maybe-executable (getenv "HTML_TIDY_PATH"))
-                      (path->string (find-executable-path "tidy"))
-                      ""))
+                      (match (find-executable-path "tidy")
+                        [(? path? p) (path->string p)] [_ ""])))
          tp]))))
 
 ;; Zero-arity functions for getting the Tidy version & testing it for sufficiency

--- a/private/tidy.rkt
+++ b/private/tidy.rkt
@@ -120,8 +120,7 @@
 ;; HTML Tidy private utilities
 ;;
 
-;; Clothe an x-expression in a <head> or <body> tag if it doesn't already
-;; start with one of those tags.
+;; Clothe an x-expression in a <body> tag if it looks like it needs one
 (define (xpr x)
   (or (and (member (car x) '(head body)) x)
       `(body (main (article ,x)))))

--- a/private/tidy.rkt
+++ b/private/tidy.rkt
@@ -15,6 +15,7 @@
 (provide tidy-path
          tidy-options
          get-tidy-version
+         minimum-tidy-version
          tidy-version-sufficient?
          tidy
          xpr)


### PR DESCRIPTION
- [x] Added `check-matches-tidy?` to check if the writer output matches HTML Tidy's output
- [x] Updated writer algorithm to write some chunks to a buffer/accumulator first

So far the new algorithm is a bit better at wrapping before the column limit in some cases, and no longer leaves trailing spaces on lines. But it can get better.

- [x] Add version and environment variable checks to Tidy checks to ensure they fail gracefully when a recent version of HTML Tidy is not available
- [x] Further update algorithm to include indicators at breakable points in the accumulator
- [x] Update tests
